### PR TITLE
Update suggested_key in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,12 @@
     },
     "commands": {
         "_execute_action": {
-            "suggested_key": "Ctrl+Comma"
+            "suggested_key": {
+                "default": "Ctrl+Comma",
+                "mac": "Command+Comma",
+                "chromeos": "Ctrl+Comma",
+                "linux": "Ctrl+Comma"
+            }
         }
     },
     "permissions": ["activeTab", "scripting", "contextMenus"]


### PR DESCRIPTION
## Description

Updates the `suggest_key` or keybind to toggle Web Edit to be more specific. 

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it-->

## Changes Made

Updates the `suggested_key` command in the manifest to include default, mac, chromeos, and linux

<!-- Describe the changes that were made in this pull request. Be as detailed as possible. -->

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it-->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

[chrome.commands - Chrome for Developers](https://developer.chrome.com/docs/extensions/reference/commands/)

## Code of Conduct

By submitting this issue, I agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
