### PR TITLE
Block click event when editing

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -22,3 +22,10 @@ if (document.body.contentEditable === 'true') {
     // Enable editing
     document.body.contentEditable = 'true';
 }
+
+// Block clicking when editing
+document.addEventListener('click', function (e) {
+    if (document.body.contentEditable === 'true') {
+        e.stopImmediatePropagation();
+    }
+}, true);


### PR DESCRIPTION
## Description

Blocks the click event when editing so links or buttons don't trigger when clicking them.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it-->

## Changes Made

* Listen to the `click` event and stop the event from reaching

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it-->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->

## Code of Conduct

By submitting this issue, I agree to follow the [Code of Conduct](https://github.com/RyanLua/WebEdit?tab=coc-ov-file).
